### PR TITLE
Fix extra income tax calculation

### DIFF
--- a/backend/model/year_simulator.py
+++ b/backend/model/year_simulator.py
@@ -38,7 +38,6 @@ class YearSimulator:
     ]:
         # SETUP
         withdrawals = []
-        extra_taxes = 0.0
         tax_calculator = TaxCalculator(
             federal_tax_brackets=config.federal_tax_brackets,
             federal_standard_deduction=config.federal_standard_deduction,
@@ -201,7 +200,7 @@ class YearSimulator:
             expenses.append(
                 Expense(
                     f"Extra income taxes for {year}",
-                    extra_taxes,
+                    extra_income_taxes,
                     year + 1,
                     tax_payment=True,
                 )


### PR DESCRIPTION
## Summary
- remove unused `extra_taxes` variable
- correctly use calculated `extra_income_taxes` when adding the tax expense

## Testing
- `PYTHONPATH=backend:jupyter-notebook pytest -q` *(fails: HousePurchase interface mismatch and ScheduledDebt legacy tests)*

------
https://chatgpt.com/codex/tasks/task_e_6852d091680c832ba40051470dc7a087