### PR TITLE
Fix payroll tax calculations

### DIFF
--- a/backend/model/tax_calculator.py
+++ b/backend/model/tax_calculator.py
@@ -24,9 +24,13 @@ class TaxCalculator:
         self.federal_tax_brackets = federal_tax_brackets
         self.federal_standard_deduction = federal_standard_deduction
         self.payroll_tax_brackets = [
+            # 7.65% (Social Security + Medicare) on wages up to the
+            # Social Security wage base
             TaxBracket(0.0765, 0.0, 168600.0),
-            TaxBracket(0.0235, 168601.0, 200000.0),
-            TaxBracket(0.009, 200001.0, float("inf")),
+            # 1.45% Medicare tax on wages above the Social Security cap
+            TaxBracket(0.0145, 168600.0, 200000.0),
+            # Additional 0.9% Medicare tax on wages above $200,000
+            TaxBracket(0.0235, 200000.0, float("inf")),
         ]
         self.payroll_standard_deduction = 0.0
 

--- a/backend/model/test_tax_calculator.py
+++ b/backend/model/test_tax_calculator.py
@@ -26,5 +26,18 @@ class TestTaxCalculator(unittest.TestCase):
         tax = self.calc.calculate_federal_income_tax(500)
         self.assertEqual(tax, 0)
 
+    def test_calculate_payroll_tax_under_cap(self):
+        tax = self.calc.calculate_payroll_tax(10000)
+        self.assertAlmostEqual(tax, 765.0, places=2)
+
+    def test_calculate_payroll_tax_above_additional_threshold(self):
+        tax = self.calc.calculate_payroll_tax(210000)
+        expected = (
+            168600 * 0.0765
+            + (200000 - 168600) * 0.0145
+            + (210000 - 200000) * 0.0235
+        )
+        self.assertAlmostEqual(tax, expected, places=2)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- correct FICA/payroll tax brackets
- test payroll tax calculations

## Testing
- `PYTHONPATH=backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860314a8680832b8346bd4d2f574ec3