### PR TITLE
Add federal tax bracket fields

### DIFF
--- a/frontend/src/components/form/FormComponent.tsx
+++ b/frontend/src/components/form/FormComponent.tsx
@@ -239,7 +239,7 @@ const FormComponent: React.FC<FormComponentProps> = ({ onSubmit, onReset, loadin
                   <Section title="Investment returns">
                     <InvestmentReturnFields />
                   </Section>
-                  <Section title="State and local income taxes" infoText="Configure the state and local income tax brackets and standard deductions. The default values are for someone living in New York, NY.">
+                  <Section title="Federal, state, and local income taxes" infoText="Configure the income tax brackets and standard deductions. The default values are for someone living in New York, NY.">
                     <IncomeTaxFields values={values.config} />
                   </Section>
                 </Accordion>

--- a/frontend/src/components/form/IncomeTaxFields.tsx
+++ b/frontend/src/components/form/IncomeTaxFields.tsx
@@ -10,6 +10,21 @@ import CollapsibleDetails from "./CollabsibleDetails";
 const IncomeTaxFields = ({ values }: { values: ConfigFieldsType }) => {
   return <>
     <FieldsContainer>
+      <CollapsibleDetails label="Federal" infoText="Default U.S. federal values">
+        <Row>
+          <Col xs={12} md={6} className="my-2">
+            <DollarInput name="config.federal_standard_deduction" label="Standard deduction" />
+          </Col>
+        </Row>
+        <Row className="p-2 m-2 bg-white rounded border border-outline-secondary">
+          <DynamicFields
+            name="config.federal_tax_brackets"
+            values={values.federal_tax_brackets}
+            initialValues={TaxBracketInput.initialValues}
+            fieldsComponent={TaxBracketInput}
+          />
+        </Row>
+      </CollapsibleDetails>
       <CollapsibleDetails label="State" infoText="The default values are for NY.">
         <Row>
           <Col xs={12} md={6} className="my-2">


### PR DESCRIPTION
## Summary
- add inputs for federal tax brackets and standard deduction
- rename income tax section title to mention federal taxes

## Testing
- `PYTHONPATH=backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686034e801e4832bbefde2e9989060ff